### PR TITLE
Make promise rejections more reliable

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ function getJSON(url) {
 		// Build XmlHttpRequest object
 		var req = new XMLHttpRequest();
 		req.onload = function() {
-			resolve(JSON.parse(req.response));
+			if (req.status < 200 || req.status >= 400) return reject(new Error('Error ' + req.status));
+			try {
+				resolve(JSON.parse(req.response));
+			} catch (err) {
+				reject(err);
+			}
 		};
 		req.onerror = reject.bind(null, new Error('Error ' + req.status));
 		req.ontimeout = reject.bind(null, new Error('Request timeout'));
@@ -27,3 +32,4 @@ function getJSON(url) {
 	});
 }
 exports.getJSON = getJSON;
+;

--- a/index.js
+++ b/index.js
@@ -32,4 +32,3 @@ function getJSON(url) {
 	});
 }
 exports.getJSON = getJSON;
-;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xhr-tool",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "XMLHttpRequest with Promises (in the browser)",
   "keywords": [ "xhr", "promises", "es6" ],
   "author": "Jannes Meyer <jannes.meyer@gmail.com>",


### PR DESCRIPTION
Promises weren't being rejected on 404 errors for me, so I added checks for the status code and JSON parsing errors.
